### PR TITLE
Adds the ability to specify the post status

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Extracts changelog information from the last closed Pull Request description and
 | wp-endpoint  | The WordPress posts endpoint the changelog will be posted at.                                  | Required            |                             |
 | start-marker | The text marker used to find the start of the changelog description inside the PR description. | Optional            | `<h2>Changelog Description` |
 | end-marker   | The text marker used to find the end of the changelog description inside the PR description.   | Optional            | `<h2>`                      |
-| wp-tag-ids   | A comma separated list of WordPress tag ids to add to the post                                 | Optional            |                             |
+| wp-status    | The WordPress post status.                                                                     | Optional            | `draft`                     |
+| wp-tag-ids   | A comma separated list of WordPress tag ids to add to the post.                                | Optional            |                             |
 
 ### Environment Variables
 

--- a/scripts/github-changelog.php
+++ b/scripts/github-changelog.php
@@ -22,6 +22,7 @@ $options = getopt( null, [
     "start-marker:",
     "end-marker:",
     "wp-endpoint:",
+    "wp-status:",
     "wp-tag-ids:",
 ] );
 
@@ -39,6 +40,7 @@ define( 'GITHUB_ENDPOINT', 'https://api.github.com/repos/' . PR_USERNAME . '/' .
 define( 'PR_CHANGELOG_START_MARKER', $options[ 'start-marker' ] ?? '<h2>Changelog Description' );
 define( 'PR_CHANGELOG_END_MARKER', $options[ 'end-marker' ] ?? '<h2>' );
 define( 'WP_CHANGELOG_ENDPOINT', $options[ 'wp-endpoint' ] );
+define( 'WP_CHANGELOG_STATUS', $options[ 'wp-status' ] ?? 'draft' );
 define( 'WP_CHANGELOG_TAG_IDS', $options[ 'wp-tag-ids' ] );
 
 function fetch_last_PR() {
@@ -111,7 +113,7 @@ function create_draft_changelog( $title, $content, $tags ) {
         'title' => $title,
         'content' => $content,
         'excerpt' => $title,
-        'status' => 'draft',
+        'status' => WP_CHANGELOG_STATUS,
         'tags' => implode( ',', $tags ),
     ];
     $ch = curl_init( WP_CHANGELOG_ENDPOINT );


### PR DESCRIPTION
Previously the status was hardcoded to be 'draft'. In [vip-ui](https://github.com/automattic/vip-ui), we deploy whenever we merge to `master`. In that case, we might want to publish the changelog right away to notify people about changes in production.

### JIRA ticket
https://vipjira.atlassian.net/browse/PIE-2639