### PR TITLE
Avoids posting changelogs with no description

### DIFF
--- a/scripts/github-changelog.php
+++ b/scripts/github-changelog.php
@@ -90,6 +90,10 @@ function get_changelog_html( $pr ) {
 
     $changelog_html = get_changelog_section_in_description_html( $description_html );
 
+    if ( empty( $changelog_html ) ) {
+        return NULL;
+    }
+
     if ( strpos($changelog_html, $pr['html_url']) === false ) {
         $changelog_html = $changelog_html . "\n\n" . $Parsedown->text( $pr['html_url'] );
     }
@@ -160,6 +164,12 @@ function create_changelog_for_last_PR() {
 
     $changelog_tags = get_changelog_tags( $pr[ 'labels' ] );
     $changelog_html = get_changelog_html( $pr );
+
+    if ( empty( $changelog_html ) ) {
+        echo "Skipping post. No changelog text found.\n";
+        exit( 0 );
+    }
+
     $changelog_record = parse_changelog_html( $changelog_html );
 
     create_draft_changelog( $changelog_record['title'], $changelog_record['content'], $changelog_tags );


### PR DESCRIPTION
If the pull request doesn't include a changelog section, the post would still be sent with an empty description (actually, only the link to the PR would be posted). This PR will skip the posting when no description is found.