### PR TITLE
Adds an option to allow configuring wether or not to include a link to the PR in the changelog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Extracts changelog information from the last closed Pull Request description and
 | end-marker   | The text marker used to find the end of the changelog description inside the PR description.   | Optional            | `<h2>`                      |
 | wp-status    | The WordPress post status.                                                                     | Optional            | `draft`                     |
 | wp-tag-ids   | A comma separated list of WordPress tag ids to add to the post.                                | Optional            |                             |
+| link-to-pr   | Wether or not to include the link to the PR in the post.                                       | Optional            | `true`                      |
 
 ### Environment Variables
 

--- a/scripts/github-changelog.php
+++ b/scripts/github-changelog.php
@@ -19,6 +19,7 @@ if ( ! is_env_set() ) {
 }
 
 $options = getopt( null, [
+    "link-to-pr",
     "start-marker:",
     "end-marker:",
     "wp-endpoint:",
@@ -42,6 +43,7 @@ define( 'PR_CHANGELOG_END_MARKER', $options[ 'end-marker' ] ?? '<h2>' );
 define( 'WP_CHANGELOG_ENDPOINT', $options[ 'wp-endpoint' ] );
 define( 'WP_CHANGELOG_STATUS', $options[ 'wp-status' ] ?? 'draft' );
 define( 'WP_CHANGELOG_TAG_IDS', $options[ 'wp-tag-ids' ] );
+define( 'LINK_TO_PR', $options[ 'link-to-pr' ] ?? true );
 
 function fetch_last_PR() {
     $ch = curl_init( GITHUB_ENDPOINT );
@@ -62,7 +64,7 @@ function fetch_last_PR() {
     $last_prs = json_decode( $data, true );
     $merged_prs = array_filter( $last_prs, function ( $pr ) { return $pr['merged_at'] ?? ''; } );
 
-    return $merged_prs[ 0 ];
+    return array_values( $merged_prs )[ 0 ];
 }
 
 function get_changelog_section_in_description_html( $description ) {
@@ -94,7 +96,7 @@ function get_changelog_html( $pr ) {
         return NULL;
     }
 
-    if ( strpos($changelog_html, $pr['html_url']) === false ) {
+    if ( LINK_TO_PR && strpos($changelog_html, $pr['html_url']) === false ) {
         $changelog_html = $changelog_html . "\n\n" . $Parsedown->text( $pr['html_url'] );
     }
     return $changelog_html;


### PR DESCRIPTION
For private repositories, we might not want want to include the link to the repository in the post. This PR adds a CLI argument that allows users to configure if the link will be included or not.