### PR TITLE
Add GitHub action to mark inactive issues and PRs as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: Stale monitor
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    name: Stale
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: Automattic/vip-actions/stale@trunk


### PR DESCRIPTION
## Description

This pull request introduces a GitHub action that runs daily and will automatically mark inactive issues and PRs as stale. Keeping issues and pull requests manageable and actionable is important for a codebase's health.

The default behavior of this action will mark issues and pull requests as stale after **60 days** of inactivity, by adding a label of `[Status] Stale` and leaving an explanatory comment ([example](https://github.com/Automattic/eslint-config-wpvip/issues/6#issuecomment-1215909749)). If another **7 days** of inactivity pass, it will be labeled `[Status] Autoclosed` and closed. (It can always be reopened, which resets the clock.)

This action ignores issues and PRs with the following labels:

- `[Pri] Critical`
- `[Status] Keep`
- `dependencies` (ensures that **Dependabot** pull requests are not marked as stale or closed)

You can easily customize the time periods used for marking an issue stale or autoclosing. Consult the documentation for details on [providing overrides](https://github.com/Automattic/vip-actions/tree/trunk/stale#inputs).

Feel free to close this pull request if it does not suit your project's needs or workflows. If you would consider merging this pull request if the action were improved in some way, please [open an issue or pull request](https://github.com/Automattic/vip-actions/tree/trunk/stale) to let us know.

## Deploy Notes

Upon merging, this action will run at about midnight UTC. Issues and pull requests that already meet the stale threshold will be immediately marked stale, but will not be autoclosed until an additional 7 days of inactivity pass.
