### PR TITLE
Send categories as comma separated string

### DIFF
--- a/lib/github-changelog.php
+++ b/lib/github-changelog.php
@@ -29,7 +29,7 @@ function fetch_last_pr() {
 		$last_prs,
 		function ( $pr ) {
 			return $pr['merged_at'] ?? '';
-		} 
+		}
 	);
 
 	return array_values( $merged_prs )[0];
@@ -105,7 +105,7 @@ function build_changelog_request_body( $title, $content, $tags, $channels, $cate
 		'excerpt'    => $title,
 		'status'     => WP_CHANGELOG_STATUS,
 		'tags'       => implode( ',', $tags ),
-		'categories' => $categories,
+		'categories' => implode( ',', $categories ),
 	);
 
 	if ( $channels ) {
@@ -173,7 +173,7 @@ function get_changelog_channels() {
 		explode( ',', WP_CHANGELOG_CHANNEL_IDS ),
 		function ( $channel ) {
 			return ! ! $channel;
-		} 
+		}
 	);
 }
 

--- a/tests/scripts/test-github-changelog.php
+++ b/tests/scripts/test-github-changelog.php
@@ -81,7 +81,7 @@ Foo Bar!';
 			'excerpt'         => $title,
 			'status'          => 'publish',
 			'tags'            => implode( ',', $tags ),
-			'categories'      => $categories,
+			'categories'      => implode( ',', $categories ),
 			'release-channel' => implode( ',', $channels ),
 		);
 


### PR DESCRIPTION
## Description

WP REST API expects categories as a single integer, an array of integers, or a comma-separated string. Currently when attempting to create the changelog post in WordPress, we are sending categories as an array of strings which causes an error: `{"code":"rest_invalid_type","message":"categories[0] is not of type integer."}`. This PR fixes that by sending them as a comma separated string, same as we do for tags.
