### PR TITLE
Add support for generating changelogs from releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ Extracts changelog information from the last closed Pull Request description and
 
 ### Options
 
-| Option       | Description                                                                                    | Required / Optional | Default Value               |
-| -------------|:----------------------------------------------------------------------------------------------:|---------------------| --------------------------- |
-| wp-endpoint  | The WordPress posts endpoint the changelog will be posted at.                                  | Required            |                             |
-| start-marker | The text marker used to find the start of the changelog description inside the PR description. | Optional            | `<h2>Changelog Description` |
-| end-marker   | The text marker used to find the end of the changelog description inside the PR description.   | Optional            | `<h2>`                      |
-| wp-status    | The WordPress post status.                                                                     | Optional            | `draft`                     |
-| wp-tag-ids   | A comma separated list of WordPress tag ids to add to the post.                                | Optional            |                             |
-| link-to-pr   | Wether or not to include the link to the PR in the post.                                       | Optional            | `true`                      |
+| Option              | Description                                                                                    | Required / Optional | Default Value               |
+|---------------------|:----------------------------------------------------------------------------------------------:|---------------------|----------------------------|
+| wp-endpoint         | The WordPress posts endpoint the changelog will be posted at.                                  | Required            |                             |
+| start-marker        | The text marker used to find the start of the changelog description inside the PR description. | Optional            | `<h2>Changelog Description` |
+| end-marker          | The text marker used to find the end of the changelog description inside the PR description.   | Optional            | `<h2>`                      |
+| wp-status           | The WordPress post status.                                                                     | Optional            | `draft`                     |
+| wp-tag-ids          | A comma separated list of WordPress tag ids to add to the post.                                | Optional            |                             |
+| link-to-pr          | Whether or not to include the link to the PR in the post.                                      | Optional            | `true`                      |
+| changelog-source    | Source to create the changelog for. Default is 'last-pr', other options are 'last-release'     | Optional            |                             |
 
 ### Environment Variables
 
@@ -39,6 +40,7 @@ Most of these variables are already [built-in](https://circleci.com/docs/2.0/env
 | CIRCLE_PROJECT_REPONAME | The name of the repository of the current project.                   | Required            |
 | CHANGELOG_POST_TOKEN    | WordPress.com auth token required to post to the endpoint.           | Required            |
 | GITHUB_TOKEN            | The GitHub personal acess token needed to read private repositories. | Optional            |
+
 
 - `CHANGELOG_POST_TOKEN` can be generated using a helper app like https://github.com/Automattic/node-wpcom-oauth ([example instructions](https://wp.me/p6jPRI-4xy#comment-26288))
 

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ Extracts changelog information from the last closed Pull Request description and
 
 ### Options
 
-| Option              | Description                                                                                    | Required / Optional | Default Value               |
-|---------------------|:----------------------------------------------------------------------------------------------:|---------------------|----------------------------|
-| wp-endpoint         | The WordPress posts endpoint the changelog will be posted at.                                  | Required            |                             |
-| start-marker        | The text marker used to find the start of the changelog description inside the PR description. | Optional            | `<h2>Changelog Description` |
-| end-marker          | The text marker used to find the end of the changelog description inside the PR description.   | Optional            | `<h2>`                      |
-| wp-status           | The WordPress post status.                                                                     | Optional            | `draft`                     |
-| wp-tag-ids          | A comma separated list of WordPress tag ids to add to the post.                                | Optional            |                             |
-| link-to-pr          | Whether or not to include the link to the PR in the post.                                      | Optional            | `true`                      |
-| changelog-source    | Source to create the changelog for. Default is 'last-pr', other options are 'last-release'     | Optional            |                             |
+| Option              | Description                                                                                                  | Required / Optional | Default Value               |
+|---------------------|:------------------------------------------------------------------------------------------------------------:|---------------------|-----------------------------|
+| wp-endpoint         | The WordPress posts endpoint the changelog will be posted at.                                                | Required            |                             |
+| start-marker        | The text marker used to find the start of the changelog description inside the PR description.               | Optional            | `<h2>Changelog Description` |
+| end-marker          | The text marker used to find the end of the changelog description inside the PR description.                 | Optional            | `<h2>`                      |
+| wp-status           | The WordPress post status.                                                                                   | Optional            | `draft`                     |
+| wp-tag-ids          | A comma separated list of WordPress tag ids to add to the post.                                              | Optional            |                             |
+| link-to-pr          | Whether or not to include the link to the PR in the post.                                                    | Optional            | `true`                      |
+| changelog-source    | Source to create the changelog for. Use `last-release` to process release notes, otherwise processes last PR | Optional            |                             |
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,12 @@ Most of these variables are already [built-in](https://circleci.com/docs/2.0/env
 
 ### Usage Example
 
-An example [CircleCI Workflow](https://circleci.com/docs/2.0/workflows/) is available [here](/examples/changelog-circleci-config.yml).
-
-The example does NOT have a valid WP TOKEN so no entry will be published.
-
-To run the example you can use circleci-cli: `circleci local execute --job create-changelog-draft --config examples/changelog-circleci-config.yml`
+```
+GITHUB_TOKEN="" CHANGELOG_POST_TOKEN="" CIRCLE_PROJECT_USERNAME="" CIRCLE_PROJECT_REPONAME="" php scripts/github-changelog.php \
+    --wp-endpoint=https://example.com/wp-json/wp/v2/posts \
+    --wp-status=draft \
+    --wp-tag-ids=1 \
+    --wp-categories=3 \
+    --link-to-pr=true \
+    --changelog-source=last-release
+```

--- a/lib/github-changelog.php
+++ b/lib/github-changelog.php
@@ -8,23 +8,25 @@ function debug( $arg ) {
 	echo 'DEBUG: ' . print_r( $arg, true );
 }
 
-function fetch_last_pr() {
-	$ch      = curl_init( GITHUB_ENDPOINT );
-	$headers = array( 'User-Agent: script' );
-
-	curl_setopt( $ch, CURLOPT_HEADER, 0 );
-	curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
-	curl_setopt( $ch, CURLOPT_VERBOSE, true );
-
+function make_github_request( $url, $headers = array() ) {
+	$ch = curl_init( $url );
 	if ( isset( $_SERVER['GITHUB_TOKEN'] ) ) {
 		array_push( $headers, 'Authorization:token ' . GITHUB_TOKEN );
 	}
-
+	$headers = array_merge( $headers, array( 'User-Agent: script' ) );
+	curl_setopt( $ch, CURLOPT_HEADER, 0 );
+	curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
 	curl_setopt( $ch, CURLOPT_HTTPHEADER, $headers );
 	$data = curl_exec( $ch );
 	curl_close( $ch );
+	return json_decode( $data, true );
+}
 
-	$last_prs   = json_decode( $data, true );
+function fetch_last_pr() {
+	$url = GITHUB_PR_ENDPOINT . '?per_page=10&sort=updated&direction=desc&state=closed';
+
+	$last_prs = make_github_request( $url );
+
 	$merged_prs = array_filter(
 		$last_prs,
 		function ( $pr ) {
@@ -35,6 +37,18 @@ function fetch_last_pr() {
 	return array_values( $merged_prs )[0];
 }
 
+function fetch_pr( $pr_id ) {
+	$url = GITHUB_PR_ENDPOINT . '/' . $pr_id;
+
+	return make_github_request( $url );
+}
+
+/**
+ * Gets the changelog section in the PR description.
+ *
+ * @param string $description The PR description
+ * @return string The changelog section in the PR description
+ */
 function get_changelog_section_in_description_html( $description ) {
 	$found_changelog_header = false;
 	$result                 = '';
@@ -42,7 +56,6 @@ function get_changelog_section_in_description_html( $description ) {
 		if ( strpos( $line, PR_CHANGELOG_START_MARKER ) === 0 ) {
 			$found_changelog_header = true;
 		} elseif ( $found_changelog_header ) {
-
 			if ( strpos( $line, PR_CHANGELOG_END_MARKER ) === 0 ) {
 				// We have hit next section
 				break;
@@ -53,7 +66,18 @@ function get_changelog_section_in_description_html( $description ) {
 	return $result;
 }
 
-function get_changelog_html( $pr ) {
+/**
+ * Finds the changelog section in the PR description and returns the HTML.
+ *
+ * @param array $pr The PR object from GitHub API
+ * @param bool $link_to_pr Whether to include a link to the PR in the changelog HTML
+ * @return string The changelog HTML
+ */
+function get_changelog_html( $pr, $link_to_pr = LINK_TO_PR ) {
+	if ( ! isset( $pr['body'] ) || empty( $pr['body'] ) ) {
+		return null;
+	}
+
 	$parsedown        = new Parsedown();
 	$body             = preg_replace( '/<!--(.|\s)*?-->/', '', $pr['body'] );
 	$description_html = $parsedown->text( $body );
@@ -64,12 +88,18 @@ function get_changelog_html( $pr ) {
 		return null;
 	}
 
-	if ( LINK_TO_PR && strpos( $changelog_html, $pr['html_url'] ) === false ) {
+	if ( $link_to_pr && strpos( $changelog_html, $pr['html_url'] ) === false ) {
 		$changelog_html = $changelog_html . "\n\n" . $parsedown->text( $pr['html_url'] );
 	}
 	return trim( $changelog_html );
 }
 
+/**
+ * Parses the changelog HTML to get the title and content for the changelog post.
+ *
+ * @param string $changelog_html The changelog HTML
+ * @return array The title and content for the changelog post
+ */
 function parse_changelog_html( $changelog_html ) {
 	preg_match( '/<h3>(.*)<\/h3>/', $changelog_html, $matches );
 
@@ -98,6 +128,16 @@ function parse_changelog_html( $changelog_html ) {
 	);
 }
 
+/**
+ * Builds the changelog request body.
+ *
+ * @param string $title The title of the changelog post
+ * @param string $content The content of the changelog post
+ * @param array $tags The tags of the changelog post
+ * @param array $channels The channels of the changelog post
+ * @param array $categories The categories of the changelog post
+ * @return array The changelog request body
+ */
 function build_changelog_request_body( $title, $content, $tags, $channels, $categories ) {
 	$fields = array(
 		'title'      => $title,
@@ -115,6 +155,16 @@ function build_changelog_request_body( $title, $content, $tags, $channels, $cate
 	return $fields;
 }
 
+/**
+ * Makes the request to create a changelog post.
+ *
+ * @param string $title The title of the changelog post
+ * @param string $content The content of the changelog post
+ * @param array $tags The tags of the changelog post
+ * @param array $channels The channels of the changelog post
+ * @param array $categories The categories of the changelog post
+ * @return void
+ */
 function create_changelog_post( $title, $content, $tags, $channels, $categories ) {
 	$fields = build_changelog_request_body( $title, $content, $tags, $channels, $categories );
 
@@ -139,12 +189,18 @@ function create_changelog_post( $title, $content, $tags, $channels, $categories 
 	}
 }
 
+/**
+ * Gets the changelog tags.
+ *
+ * @param array $github_labels The GitHub labels
+ * @return array The changelog tags
+ */
 function get_changelog_tags( $github_labels ) {
 	$tags = explode( ',', WP_CHANGELOG_TAG_IDS );
 
 	if ( isset( $github_labels ) && count( $github_labels ) > 0 ) {
 		foreach ( $github_labels as $label ) {
-			preg_match( '/ChangelogTagID:\s*(\d+)/', $label['description'], $matches );
+			preg_match( '/ChangelogTagID:\s*(\d+)/', $label['description'] ?? '', $matches );
 			if ( $matches ) {
 				array_push( $tags, $matches[1] );
 			}
@@ -154,6 +210,11 @@ function get_changelog_tags( $github_labels ) {
 	return $tags;
 }
 
+/**
+ * Gets the changelog categories.
+ *
+ * @return array The changelog categories
+ */
 function get_changelog_categories() {
 	$categories = explode( ',', WP_CHANGELOG_CATEGORIES );
 
@@ -168,15 +229,25 @@ function get_changelog_categories() {
 	return array_values( $filtered );
 }
 
+/**
+ * Gets the changelog channels.
+ *
+ * @return array The changelog channels
+ */
 function get_changelog_channels() {
 	return array_filter(
 		explode( ',', WP_CHANGELOG_CHANNEL_IDS ),
 		function ( $channel ) {
-			return ! ! $channel;
+			return (bool) $channel;
 		}
 	);
 }
 
+/**
+ * Creates a changelog post from the latest PR.
+ *
+ * @return void
+ */
 function create_changelog_for_last_pr() {
 	$pr = fetch_last_pr();
 
@@ -203,5 +274,214 @@ function create_changelog_for_last_pr() {
 	$changelog_record = parse_changelog_html( $changelog_html );
 
 	create_changelog_post( $changelog_record['title'], $changelog_record['content'], $changelog_tags, $changelog_channels, $changelog_categories );
+	echo "\n\nAll done!";
+}
+
+/**
+ * Fetches releases from GitHub.
+ *
+ * @param int $count The number of releases to fetch
+ * @return array The fetched releases
+ */
+function fetch_releases( $count = 1 ) {
+	$url = GITHUB_RELEASE_ENDPOINT . '?per_page=' . $count . '&sort=updated&direction=desc';
+
+	$releases = make_github_request( $url );
+
+	return $releases;
+}
+
+/**
+ * Fetches PRs by their IDs.
+ *
+ * @param array $pr_ids The array of PR IDs to fetch
+ * @return array The fetched PRs
+ */
+function fetch_prs_by_ids( $pr_ids ) {
+	$prs = array();
+	$fetched_ids   = array();
+
+	foreach ( $pr_ids as $pr_id ) {
+		// Skip if we've already fetched this PR
+		if ( in_array( $pr_id, $fetched_ids ) ) {
+			continue;
+		}
+		$fetched_ids[] = $pr_id;
+
+		// Get the PR details
+		$pr = fetch_pr( $pr_id );
+		if ( ! $pr ) {
+			continue;
+		}
+
+		$prs[] = $pr;
+	}
+
+	return $prs;
+}
+
+/**
+ * Extracts PR IDs from a message like a commit message or release notes.
+ *
+ * @param string $message The message to extract PR IDs from
+ * @return array The extracted PR IDs
+ */
+function get_pr_ids_from_message( $message ) {
+	$pr_ids = array();
+
+	// Match PR references in commit messages
+	if ( 1 === preg_match( '/\(\#[0-9]+\)/', $message, $matches ) ||
+		1 === preg_match( '/^Merge pull request #[0-9]+/', $message, $matches ) ) {
+		$pr_ids[] = preg_replace( '/[^0-9]/', '', $matches[0] );
+	}
+
+	// Match PR references in release notes format
+	// Example: "* chore: Update dependency by @user in https://github.com/Automattic/vip-cli/pull/1234"
+	if ( preg_match_all( '/\/pull\/(\d+)/', $message, $matches ) ) {
+		$pr_ids = array_merge( $pr_ids, $matches[1] );
+	}
+
+	return array_unique( $pr_ids );
+}
+
+/**
+ * Aggregates changelog content by grouping items under their respective headings.
+ *
+ * @param string $html The HTML content to aggregate
+ * @return string The aggregated HTML or original content if aggregation fails
+ */
+function aggregate_changelog_headings( string $html ): string {
+	if ( empty( trim( $html ) ) ) {
+		return '';
+	}
+
+	$dom = new DOMDocument();
+	libxml_use_internal_errors( true );
+
+	if ( ! $dom->loadHTML( '<?xml encoding="utf-8" ?>' . $html ) ) {
+		return $html;
+	}
+	libxml_clear_errors();
+
+	$root = $dom->getElementsByTagName( 'body' )->item( 0 ) ?? $dom->documentElement;
+	if ( ! $root ) {
+		return $html;
+	}
+
+	$aggregated     = array();
+	$currentHeading = null;
+
+	foreach ( $root->childNodes as $node ) {
+		if ( $node->nodeType !== XML_ELEMENT_NODE ) {
+			continue;
+		}
+
+		if ( $node->nodeName === 'h3' ) {
+			$currentHeading                  = $node->textContent;
+			$aggregated[ $currentHeading ] ??= array();
+			continue;
+		}
+
+		if ( ! $currentHeading ) {
+			continue;
+		}
+
+		// Handle ul and p elements
+		if ( $node->nodeName === 'ul' ) {
+			foreach ( $node->getElementsByTagName( 'li' ) as $li ) {
+				$aggregated[ $currentHeading ][] = trim( $dom->saveHTML( $li ) );
+			}
+		} elseif ( $node->nodeName === 'p' ) {
+			$aggregated[ $currentHeading ][] = trim( $dom->saveHTML( $node ) );
+		}
+	}
+
+	$output = '';
+	foreach ( $aggregated as $heading => $items ) {
+		if ( empty( $items ) ) {
+			continue;
+		}
+		$output .= '<h3>' . $heading . "</h3>\n";
+		$output .= "<ul>\n";
+		foreach ( $items as $item ) {
+			$output  .= '<li>' . trim( strip_tags( $item, '<code>' ) ) . "</li>\n";
+		}
+		$output .= "</ul>\n";
+	}
+
+	return trim( $output );
+}
+
+/**
+ * Creates a changelog post from the latest release.
+ *
+ * @return void
+ */
+function create_changelog_for_last_release() {
+	$releases = fetch_releases( 1 );
+	$release  = $releases[0];
+
+	if ( ! isset( $release['id'] ) ) {
+		echo "Failed to retrieve last release.\n";
+		exit( 1 );
+	}
+
+	if ( ! isset( $release['body'] ) ) {
+		echo "No body found for the latest release.\n";
+		exit( 0 );
+	}
+
+	$pr_ids = get_pr_ids_from_message( $release['body'] );
+
+	if ( empty( $pr_ids ) ) {
+		echo "No PRs found for the latest release.\n";
+		exit( 0 );
+	}
+
+	$prs = fetch_prs_by_ids( $pr_ids );
+
+	$all_changelog_html = '';
+	$all_tags           = array();
+
+	foreach ( $prs as $pr ) {
+		$changelog_html = get_changelog_html( $pr, false );
+
+		if ( ! empty( $changelog_html ) ) {
+			$all_changelog_html .= "\n\n" . $changelog_html;
+			$pr_tags             = get_changelog_tags( $pr['labels'] );
+			$all_tags            = array_merge( $all_tags, $pr_tags );
+		}
+	}
+
+	if ( empty( $all_changelog_html ) ) {
+		echo "No changelog entries found in any PRs for this release.\n";
+		exit( 0 );
+	}
+
+	if ( count( $prs ) > 1 ) {
+		$all_changelog_html = aggregate_changelog_headings( $all_changelog_html );
+	}
+
+	if ( LINK_TO_PR ) {
+		$all_changelog_html = $all_changelog_html . "\n\n" . $release['html_url'];
+	}
+
+	// Use release name and date as title
+	$title = $release['name'];
+
+	if ( ! $title ) {
+		$title = gmdate( 'o-m-d H:i', strtotime( $release['created_at'] ) );
+	}
+
+	// Remove duplicate tags
+	$all_tags = array_unique( $all_tags );
+
+	$changelog_categories = get_changelog_categories();
+	$changelog_channels   = get_changelog_channels();
+
+	debug( $all_changelog_html );
+
+	create_changelog_post( $title, $all_changelog_html, $all_tags, $changelog_channels, $changelog_categories );
+
 	echo "\n\nAll done!";
 }

--- a/lib/github-changelog.php
+++ b/lib/github-changelog.php
@@ -34,7 +34,13 @@ function fetch_last_pr() {
 		}
 	);
 
-	return array_values( $merged_prs )[0];
+	$merged_prs_array = array_values( $merged_prs );
+
+	if ( empty( $merged_prs_array ) ) {
+		return null;
+	}
+
+	return $merged_prs_array[0];
 }
 
 function fetch_pr( $pr_id ) {
@@ -419,12 +425,13 @@ function aggregate_changelog_headings( string $html ): string {
  */
 function create_changelog_for_last_release() {
 	$releases = fetch_releases( 1 );
-	$release  = $releases[0];
 
-	if ( ! isset( $release['id'] ) ) {
-		echo "Failed to retrieve last release.\n";
-		exit( 1 );
+	if ( empty( $releases ) ) {
+		echo "No releases found.\n";
+		exit( 0 );
 	}
+
+	$release  = $releases[0];
 
 	if ( ! isset( $release['body'] ) ) {
 		echo "No body found for the latest release.\n";

--- a/lib/github-changelog.php
+++ b/lib/github-changelog.php
@@ -9,11 +9,13 @@ function debug( $arg ) {
 }
 
 function make_github_request( $url, $headers = array() ) {
-	$ch = curl_init( $url );
-	if ( isset( $_SERVER['GITHUB_TOKEN'] ) ) {
-		array_push( $headers, 'Authorization:token ' . GITHUB_TOKEN );
-	}
+	$ch      = curl_init( $url );
 	$headers = array_merge( $headers, array( 'User-Agent: script' ) );
+
+	if ( isset( $_SERVER['GITHUB_TOKEN'] ) ) {
+		$headers = array_merge( $headers, array( 'Authorization:token ' . GITHUB_TOKEN ) );
+	}
+
 	curl_setopt( $ch, CURLOPT_HEADER, 0 );
 	curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
 	curl_setopt( $ch, CURLOPT_HTTPHEADER, $headers );
@@ -80,7 +82,7 @@ function get_changelog_section_in_description_html( $description ) {
  * @return string The changelog HTML
  */
 function get_changelog_html( $pr, $link_to_pr = LINK_TO_PR ) {
-	if ( ! isset( $pr['body'] ) || empty( $pr['body'] ) ) {
+	if ( empty( $pr['body'] ) ) {
 		return null;
 	}
 
@@ -304,8 +306,8 @@ function fetch_releases( $count = 1 ) {
  * @return array The fetched PRs
  */
 function fetch_prs_by_ids( $pr_ids ) {
-	$prs = array();
-	$fetched_ids   = array();
+	$prs         = array();
+	$fetched_ids = array();
 
 	foreach ( $pr_ids as $pr_id ) {
 		// Skip if we've already fetched this PR
@@ -404,13 +406,14 @@ function aggregate_changelog_headings( string $html ): string {
 
 	$output = '';
 	foreach ( $aggregated as $heading => $items ) {
+		// Skip if there are no nodes under this heading
 		if ( empty( $items ) ) {
 			continue;
 		}
 		$output .= '<h3>' . $heading . "</h3>\n";
 		$output .= "<ul>\n";
 		foreach ( $items as $item ) {
-			$output  .= '<li>' . trim( strip_tags( $item, '<code>' ) ) . "</li>\n";
+			$output .= '<li>' . trim( strip_tags( $item, '<code>' ) ) . "</li>\n";
 		}
 		$output .= "</ul>\n";
 	}
@@ -431,7 +434,7 @@ function create_changelog_for_last_release() {
 		exit( 0 );
 	}
 
-	$release  = $releases[0];
+	$release = $releases[0];
 
 	if ( ! isset( $release['body'] ) ) {
 		echo "No body found for the latest release.\n";

--- a/lib/github-changelog.php
+++ b/lib/github-changelog.php
@@ -371,38 +371,40 @@ function aggregate_changelog_headings( string $html ): string {
 	}
 	libxml_clear_errors();
 
+	// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	$root = $dom->getElementsByTagName( 'body' )->item( 0 ) ?? $dom->documentElement;
 	if ( ! $root ) {
 		return $html;
 	}
 
 	$aggregated     = array();
-	$currentHeading = null;
+	$current_heading = null;
 
 	foreach ( $root->childNodes as $node ) {
-		if ( $node->nodeType !== XML_ELEMENT_NODE ) {
+		if ( XML_ELEMENT_NODE !== $node->nodeType ) {
 			continue;
 		}
 
-		if ( $node->nodeName === 'h3' ) {
-			$currentHeading                  = $node->textContent;
-			$aggregated[ $currentHeading ] ??= array();
+		if ( 'h3' === $node->nodeName ) {
+			$current_heading                  = $node->textContent;
+			$aggregated[ $current_heading ] ??= array();
 			continue;
 		}
 
-		if ( ! $currentHeading ) {
+		if ( ! $current_heading ) {
 			continue;
 		}
 
 		// Handle ul and p elements
-		if ( $node->nodeName === 'ul' ) {
+		if ( 'ul' === $node->nodeName ) {
 			foreach ( $node->getElementsByTagName( 'li' ) as $li ) {
-				$aggregated[ $currentHeading ][] = trim( $dom->saveHTML( $li ) );
+				$aggregated[ $current_heading ][] = trim( $dom->saveHTML( $li ) );
 			}
-		} elseif ( $node->nodeName === 'p' ) {
-			$aggregated[ $currentHeading ][] = trim( $dom->saveHTML( $node ) );
+		} elseif ( 'p' === $node->nodeName ) {
+			$aggregated[ $current_heading ][] = trim( $dom->saveHTML( $node ) );
 		}
 	}
+	// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 	$output = '';
 	foreach ( $aggregated as $heading => $items ) {

--- a/scripts/github-changelog.php
+++ b/scripts/github-changelog.php
@@ -60,7 +60,7 @@ define( 'LINK_TO_PR', ( $options['link-to-pr'] ?? 'true' ) !== 'false' );
 define( 'VERIFY_COMMIT_HASH', $options['verify-commit-hash'] ?? true );
 define( 'DEBUG', array_key_exists( 'debug', $options ) );
 
-if ( isset( $options['changelog-source'] ) && $options['changelog-source'] === 'last-release' ) {
+if ( isset( $options['changelog-source'] ) && 'last-release' === $options['changelog-source'] ) {
 	create_changelog_for_last_release();
 } else {
 	create_changelog_for_last_pr();

--- a/scripts/github-changelog.php
+++ b/scripts/github-changelog.php
@@ -21,9 +21,9 @@ if ( ! is_env_set() ) {
 }
 
 $options = getopt(
-	null,
+	'',
 	array(
-		'link-to-pr', // Add link to the PR at the button of the changelog entry
+		'link-to-pr:', // Add link to the PR at the button of the changelog entry
 		'start-marker:', // Text bellow line matching this param will be considered changelog entry
 		'end-marker:', // Text untill this line will be considered changelog entry
 		'wp-endpoint:', // Endpoint to wordpress site to create posts for
@@ -33,7 +33,8 @@ $options = getopt(
 		'wp-channel-ids:', // Channel IDs to add to the changelog post
 		'verify-commit-hash', // Use --verify-commit-hash=false in order to skip hash validation. This is usefull when testing the integration
 		'debug', // Show debug information
-	) 
+		'changelog-source:', // Source to create the changelog for. Default is 'last-pr', other options are 'last-release'
+	)
 );
 
 if ( ! isset( $options['wp-endpoint'] ) ) {
@@ -46,17 +47,21 @@ define( 'PROJECT_USERNAME', $_SERVER['CIRCLE_PROJECT_USERNAME'] ?? '' );
 define( 'PROJECT_REPONAME', $_SERVER['CIRCLE_PROJECT_REPONAME'] ?? '' );
 define( 'CHANGELOG_POST_TOKEN', $_SERVER['CHANGELOG_POST_TOKEN'] ?? '' );
 define( 'GITHUB_TOKEN', $_SERVER['GITHUB_TOKEN'] ?? '' );
-
-define( 'GITHUB_ENDPOINT', 'https://api.github.com/repos/' . PROJECT_USERNAME . '/' . PROJECT_REPONAME . '/pulls?per_page=10&sort=updated&direction=desc&state=closed' );
+define( 'GITHUB_PR_ENDPOINT', 'https://api.github.com/repos/' . PROJECT_USERNAME . '/' . PROJECT_REPONAME . '/pulls' );
+define( 'GITHUB_RELEASE_ENDPOINT', 'https://api.github.com/repos/' . PROJECT_USERNAME . '/' . PROJECT_REPONAME . '/releases' );
 define( 'PR_CHANGELOG_START_MARKER', $options['start-marker'] ?? '<h2>Changelog Description' );
 define( 'PR_CHANGELOG_END_MARKER', $options['end-marker'] ?? '<h2>' );
 define( 'WP_CHANGELOG_ENDPOINT', $options['wp-endpoint'] );
 define( 'WP_CHANGELOG_STATUS', $options['wp-status'] ?? 'draft' );
-define( 'WP_CHANGELOG_TAG_IDS', $options['wp-tag-ids'] );
-define( 'WP_CHANGELOG_CATEGORIES', $options['wp-categories'] );
-define( 'WP_CHANGELOG_CHANNEL_IDS', $options['wp-channel-ids'] );
-define( 'LINK_TO_PR', $options['link-to-pr'] ?? true );
+define( 'WP_CHANGELOG_TAG_IDS', $options['wp-tag-ids'] ?? '' );
+define( 'WP_CHANGELOG_CATEGORIES', $options['wp-categories'] ?? '' );
+define( 'WP_CHANGELOG_CHANNEL_IDS', $options['wp-channel-ids'] ?? '' );
+define( 'LINK_TO_PR', ( $options['link-to-pr'] ?? 'true' ) !== 'false' );
 define( 'VERIFY_COMMIT_HASH', $options['verify-commit-hash'] ?? true );
 define( 'DEBUG', array_key_exists( 'debug', $options ) );
 
-create_changelog_for_last_pr();
+if ( isset( $options['changelog-source'] ) && $options['changelog-source'] === 'last-release' ) {
+	create_changelog_for_last_release();
+} else {
+	create_changelog_for_last_pr();
+}

--- a/tests/scripts/test-github-changelog.php
+++ b/tests/scripts/test-github-changelog.php
@@ -46,7 +46,7 @@ Foo Bar!';
 <li>Fixed a bug</li>
 <li>Fixed another bug</li>
 </ul>',
-			$changelog 
+			$changelog
 		);
 	}
 
@@ -106,7 +106,7 @@ Foo Bar!';
 <li>Fixed a bug</li>
 <li>Fixed another bug</li>
 </ul>',
-			$parsed['content'] 
+			$parsed['content']
 		);
 	}
 
@@ -119,5 +119,76 @@ Foo Bar!';
 
 		$this->assertEquals( gmdate( 'o-m-d H:i' ), $parsed['title'] );
 		$this->assertEquals( $html, $parsed['content'] );
+	}
+
+	/**
+	 * @dataProvider changelog_html_provider
+	 */
+	public function test_aggregate_changelog_headings( string $input, string $expected ) {
+		$this->assertEquals(
+			$expected,
+			aggregate_changelog_headings( $input )
+		);
+	}
+
+	public function changelog_html_provider(): array {
+		return array(
+			'original test case'       => array(
+				'<h3>Fixed</h3>
+				<ul>
+				<li>Fixed a bug</li>
+				</ul>
+				<h3>Added</h3>
+				<ul>
+				<li>Added a feature</li>
+				<li>Added another feature</li>
+				</ul>
+				<h3>Fixed</h3>
+				<ul>
+				<li>Fixed another bug</li>
+				</ul>
+				<h3>Added</h3>
+				<p>Added yet another feature</p>',
+				'<h3>Fixed</h3>
+<ul>
+<li>Fixed a bug</li>
+<li>Fixed another bug</li>
+</ul>
+<h3>Added</h3>
+<ul>
+<li>Added a feature</li>
+<li>Added another feature</li>
+<li>Added yet another feature</li>
+</ul>',
+			),
+			'empty input'              => array(
+				'',
+				'',
+			),
+			'single heading'           => array(
+				'<h3>Fixed</h3>',
+				'',
+			),
+			'content without headings' => array(
+				'<p>Some content</p>',
+				'',
+			),
+			'content with code tags'   => array(
+				'<h3>Fixed</h3>
+				<ul>
+				<li>Fixed a bug in <code>function()</code></li>
+				</ul>
+				<h3>Added</h3>
+				<p>Added a <code>feature</code></p>',
+				'<h3>Fixed</h3>
+<ul>
+<li>Fixed a bug in <code>function()</code></li>
+</ul>
+<h3>Added</h3>
+<ul>
+<li>Added a <code>feature</code></li>
+</ul>',
+			),
+		);
 	}
 }


### PR DESCRIPTION
## Description

Adds support for generating changelogs from PRs which form part of a release (as is the case for repos like VIP-CLI). When the `changelog-source` option is set to `last-release`, the script will look for our changelog section in each PR mentioned in the release notes and aggregate them by the standard headings (`Added`, `Changed` etc). If a `changelog-source` option is not provided, the script will operate as it currently does, looking for the changelog section of the last merged PR.

### Testing instructions

1. Give yourself access to the repo for site 4812
2. Navigate to `/actions/workflows/changelog.yml` in that repo - the workflow is configured to use this branch.
3. Choose `last-release` as the source from the workflow options
4. Trigger the workflow and verify that it runs successfully
5. Unset the source option and run the workflow again
6. Verify it runs and succeeds