### PR TITLE
Add support for compiling a changelog from a release PR

### DIFF
--- a/lib/github-changelog.php
+++ b/lib/github-changelog.php
@@ -257,12 +257,16 @@ function build_changelog_request_body( $title, $content, $tags, $channels, $cate
  * @return void
  */
 function create_changelog_post( $title, $content, $tags, $channels, $categories ) {
-	$fields = build_changelog_request_body( $title, $content, $tags, $channels, $categories );
+	$fields      = build_changelog_request_body( $title, $content, $tags, $channels, $categories );
+	$auth_header = 'Authorization: Bearer ' . CHANGELOG_POST_TOKEN;
+	if ( 'basic' === strtolower( CHANGELOG_POST_AUTH_TYPE ) ) {
+		$auth_header = 'Authorization: Basic ' . base64_encode( CHANGELOG_POST_TOKEN );
+	}
 
 	$ch = curl_init( WP_CHANGELOG_ENDPOINT );
 	curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
 	curl_setopt( $ch, CURLOPT_POST, true );
-	curl_setopt( $ch, CURLOPT_HTTPHEADER, array( 'Authorization:Bearer ' . CHANGELOG_POST_TOKEN ) );
+	curl_setopt( $ch, CURLOPT_HTTPHEADER, array( $auth_header ) );
 	curl_setopt( $ch, CURLOPT_POSTFIELDS, $fields );
 	$response  = curl_exec( $ch );
 	$http_code = curl_getinfo( $ch, CURLINFO_RESPONSE_CODE );
@@ -377,8 +381,8 @@ function create_changelog_for_last_pr() {
 	$prs = array_merge( array( $pr ), get_referenced_prs( $pr ) );
 
 	list( $changelog_html, $changelog_tags ) = generate_changelog_from_prs( $prs );
-	$changelog_categories = get_changelog_categories();
-	$changelog_channels   = get_changelog_channels();
+	$changelog_categories                    = get_changelog_categories();
+	$changelog_channels                      = get_changelog_channels();
 
 	// Add a link to the PR if requested.
 	if ( LINK_TO_PR ) {

--- a/lib/github-changelog.php
+++ b/lib/github-changelog.php
@@ -39,11 +39,17 @@ function make_github_request( $url, $headers = array() ) {
  * @return array $data The array with all the data
  */
 function make_github_request_paginated( $url ) {
-	$all_data = [];
-    $pagination_url = $url . '?per_page=50&page=';
-	for ( $page = 1; ! empty( $data = make_github_request( $pagination_url . $page ) ); $page++ ) {
+	$all_data       = array();
+	$pagination_url = $url . '?per_page=50&page=';
+
+	for ( $page = 1; ; $page++ ) {
+		$data = make_github_request( $pagination_url . $page );
+		if ( empty( $data ) ) {
+			break;
+		}
 		$all_data = array_merge( $all_data, $data );
 	}
+
 	return $all_data;
 }
 
@@ -54,19 +60,19 @@ function make_github_request_paginated( $url ) {
  * @return array The PR objects from PR IDs referenced in the commits
  */
 function get_referenced_prs( $pr ) {
-	$commits = make_github_request_paginated( $pr['_links']['commits']['href']);
-    $pr_ids = [];
+	$commits = make_github_request_paginated( $pr['_links']['commits']['href'] );
+	$pr_ids  = array();
 
-    foreach( $commits as $commit ) {
-        $msg = $commit['commit']['message'];
+	foreach ( $commits as $commit ) {
+		$msg = $commit['commit']['message'];
 
-        echo "Checking commit: {$commit['sha']}\n";
-        if ( 1 === preg_match( '/\(\#[0-9]+\)/', $msg, $matches ) || 1 === preg_match( '/^Merge pull request #[0-9]+/', $msg, $matches ) ) {
-            $id = preg_replace('/[^0-9]/', '', $matches[0] );
-            echo "Found PR ID: $id\n";
-            $pr_ids[] = $id;
-        }
-    }
+		echo "Checking commit: {$commit['sha']}\n";
+		if ( 1 === preg_match( '/\(\#[0-9]+\)/', $msg, $matches ) || 1 === preg_match( '/^Merge pull request #[0-9]+/', $msg, $matches ) ) {
+			$id = preg_replace( '/[^0-9]/', '', $matches[0] );
+			echo "Found PR ID: $id\n";
+			$pr_ids[] = $id;
+		}
+	}
 
 	$prs = fetch_prs_by_ids( $pr_ids );
 
@@ -477,7 +483,7 @@ function aggregate_changelog_headings( string $html ): string {
 		return $html;
 	}
 
-	$aggregated     = array();
+	$aggregated      = array();
 	$current_heading = null;
 
 	foreach ( $root->childNodes as $node ) {

--- a/lib/github-changelog.php
+++ b/lib/github-changelog.php
@@ -352,7 +352,7 @@ function generate_changelog_from_prs( $prs ) {
 		}
 	}
 
-	return array( $all_changelog_html, $all_tags );
+	return array( $all_changelog_html, array_unique( $all_tags ) );
 }
 
 /**
@@ -376,10 +376,7 @@ function create_changelog_for_last_pr() {
 	// The last merged PR and any PRs found in its commits.
 	$prs = array_merge( array( $pr ), get_referenced_prs( $pr ) );
 
-	if ( ! empty( $prs ) ) {
-		list( $changelog_html, $changelog_tags ) = generate_changelog_from_prs( $prs );
-	}
-
+	list( $changelog_html, $changelog_tags ) = generate_changelog_from_prs( $prs );
 	$changelog_categories = get_changelog_categories();
 	$changelog_channels   = get_changelog_channels();
 
@@ -583,9 +580,6 @@ function create_changelog_for_last_release() {
 	if ( LINK_TO_PR ) {
 		$changelog_html = $changelog_html . "\n\n" . $release['html_url'];
 	}
-
-	// Remove duplicate tags
-	$changelog_tags = array_unique( $changelog_tags );
 
 	$changelog_categories = get_changelog_categories();
 	$changelog_channels   = get_changelog_channels();

--- a/lib/github-changelog.php
+++ b/lib/github-changelog.php
@@ -87,8 +87,8 @@ function get_referenced_prs( $pr ) {
 function fetch_last_pr() {
 	$url = GITHUB_PR_ENDPOINT . '?per_page=10&sort=updated&direction=desc&state=closed';
 
-	if ( '' !== BRANCH ) {
-		$url .= '&base=' . BRANCH;
+	if ( '' !== GITHUB_BASE_BRANCH ) {
+		$url .= '&base=' . GITHUB_BASE_BRANCH;
 	}
 
 	$last_prs = make_github_request( $url );
@@ -364,7 +364,7 @@ function create_changelog_for_last_pr() {
 	}
 
 	// The last merged PR and any PRs found in its commits.
-	$prs = array_merge( $pr, get_referenced_prs( $pr ) );
+	$prs = array_merge( array( $pr ), get_referenced_prs( $pr ) );
 
 	if ( ! empty( $prs ) ) {
 		list( $changelog_html, $changelog_tags ) = generate_changelog_from_prs( $prs );

--- a/scripts/github-changelog.php
+++ b/scripts/github-changelog.php
@@ -47,6 +47,7 @@ define( 'PROJECT_USERNAME', $_SERVER['CIRCLE_PROJECT_USERNAME'] ?? '' );
 define( 'PROJECT_REPONAME', $_SERVER['CIRCLE_PROJECT_REPONAME'] ?? '' );
 define( 'GITHUB_BASE_BRANCH', $_SERVER['GITHUB_BASE_BRANCH'] ?? '' );
 define( 'CHANGELOG_POST_TOKEN', $_SERVER['CHANGELOG_POST_TOKEN'] ?? '' );
+define( 'CHANGELOG_POST_AUTH_TYPE', $_SERVER['CHANGELOG_POST_AUTH_TYPE'] ?? 'bearer' );
 define( 'GITHUB_TOKEN', $_SERVER['GITHUB_TOKEN'] ?? '' );
 define( 'GITHUB_PR_ENDPOINT', 'https://api.github.com/repos/' . PROJECT_USERNAME . '/' . PROJECT_REPONAME . '/pulls' );
 define( 'GITHUB_RELEASE_ENDPOINT', 'https://api.github.com/repos/' . PROJECT_USERNAME . '/' . PROJECT_REPONAME . '/releases' );

--- a/scripts/github-changelog.php
+++ b/scripts/github-changelog.php
@@ -45,7 +45,7 @@ if ( ! isset( $options['wp-endpoint'] ) ) {
 define( 'SHA1', $_SERVER['CIRCLE_SHA1'] ?? '' );
 define( 'PROJECT_USERNAME', $_SERVER['CIRCLE_PROJECT_USERNAME'] ?? '' );
 define( 'PROJECT_REPONAME', $_SERVER['CIRCLE_PROJECT_REPONAME'] ?? '' );
-define( 'BRANCH', $_SERVER['GITHUB_BRANCH'] ?? '' );
+define( 'GITHUB_BASE_BRANCH', $_SERVER['GITHUB_BASE_BRANCH'] ?? '' );
 define( 'CHANGELOG_POST_TOKEN', $_SERVER['CHANGELOG_POST_TOKEN'] ?? '' );
 define( 'GITHUB_TOKEN', $_SERVER['GITHUB_TOKEN'] ?? '' );
 define( 'GITHUB_PR_ENDPOINT', 'https://api.github.com/repos/' . PROJECT_USERNAME . '/' . PROJECT_REPONAME . '/pulls' );

--- a/scripts/github-changelog.php
+++ b/scripts/github-changelog.php
@@ -45,6 +45,7 @@ if ( ! isset( $options['wp-endpoint'] ) ) {
 define( 'SHA1', $_SERVER['CIRCLE_SHA1'] ?? '' );
 define( 'PROJECT_USERNAME', $_SERVER['CIRCLE_PROJECT_USERNAME'] ?? '' );
 define( 'PROJECT_REPONAME', $_SERVER['CIRCLE_PROJECT_REPONAME'] ?? '' );
+define( 'BRANCH', $_SERVER['GITHUB_BRANCH'] ?? '' );
 define( 'CHANGELOG_POST_TOKEN', $_SERVER['CHANGELOG_POST_TOKEN'] ?? '' );
 define( 'GITHUB_TOKEN', $_SERVER['GITHUB_TOKEN'] ?? '' );
 define( 'GITHUB_PR_ENDPOINT', 'https://api.github.com/repos/' . PROJECT_USERNAME . '/' . PROJECT_REPONAME . '/pulls' );

--- a/tests/scripts/test-github-changelog.php
+++ b/tests/scripts/test-github-changelog.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/../../lib/github-changelog.php';
 define( 'PR_CHANGELOG_START_MARKER', '<h2>Changelog Description' );
 define( 'PR_CHANGELOG_END_MARKER', '<h2>' );
 define( 'LINK_TO_PR', false );
+define( 'PROJECT_REPONAME', 'test-project' );
 
 class GitHub_Changelog_Test extends TestCase {
 	public function test_get_changelog_html(): void {
@@ -99,7 +100,7 @@ Foo Bar!';
 
 		$parsed = parse_changelog_html( $html );
 
-		$this->assertEquals( gmdate( 'o-m-d H:i' ), $parsed['title'] );
+		$this->assertEquals( 'test-project ' . gmdate( 'o-m-d H:i' ), $parsed['title'] );
 		$this->assertEquals(
 			'<h3>Fixed</h3>
 <ul>
@@ -110,15 +111,27 @@ Foo Bar!';
 		);
 	}
 
-	public function test_parse_changelog_html_with_no_title_found(): void {
-		$pr = array();
-
-		$html = 'this is the html of my changelog, it does not contain a title so it needs to autogenerate';
+	public function test_parse_changelog_html_with_duplicate_sections() {
+		$html = '<h3>Fixed</h3>
+		<ul>
+		<li>Fixed a bug</li>
+		</ul>
+		<h3>Fixed</h3>
+		<ul>
+		<li>Fixed another bug</li>
+		</ul>';
 
 		$parsed = parse_changelog_html( $html );
 
-		$this->assertEquals( gmdate( 'o-m-d H:i' ), $parsed['title'] );
-		$this->assertEquals( $html, $parsed['content'] );
+		$this->assertEquals( 'test-project ' . gmdate( 'o-m-d H:i' ), $parsed['title'] );
+		$this->assertEquals(
+			'<h3>Fixed</h3>
+<ul>
+<li>Fixed a bug</li>
+<li>Fixed another bug</li>
+</ul>',
+			$parsed['content']
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description

To support Git-Flow–style releases, this PR adds the ability to compile a changelog from the pull requests referenced in a PR’s commits.

### Testing instructions

- Give yourself access to the repo for site 4812
- Navigate to `/actions/workflows/changelog.yml` in that repo - the workflow is configured to use this branch.
- Leave the source in the workflow options blank
- Trigger the workflow and verify that it runs successfully