### PR TITLE
Clean changelog entry

### DIFF
--- a/lib/github-changelog.php
+++ b/lib/github-changelog.php
@@ -166,12 +166,17 @@ function clean_changelog_html( $html ) {
 	}
 
 	$dom = new DOMDocument();
-	libxml_use_internal_errors( true );
+	
+	$previous_use_internal_errors = libxml_use_internal_errors( true );
 
-	if ( ! $dom->loadHTML( '<?xml encoding="utf-8" ?>' . $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD ) ) {
-		return $html;
+	try {
+		if ( ! $dom->loadHTML( '<?xml encoding="utf-8" ?>' . $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD ) ) {
+			return $html;
+		}
+	} finally {
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous_use_internal_errors );
 	}
-	libxml_clear_errors();
 
 	// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	$xpath = new DOMXPath( $dom );
@@ -229,7 +234,7 @@ function clean_changelog_html( $html ) {
 
 	// Normalize whitespace - remove blank lines between tags.
 	$output = preg_replace( '/>\s+</', ">\n<", $output );
-	
+
 	// Ensure consistent formatting with newlines after opening/closing tags.
 	$output = preg_replace( '/<\/h3>\s*</', "</h3>\n<", $output );
 	$output = preg_replace( '/<\/p>\s*</', "</p>\n<", $output );
@@ -628,12 +633,17 @@ function aggregate_changelog_headings( string $html ): string {
 	}
 
 	$dom = new DOMDocument();
-	libxml_use_internal_errors( true );
 
-	if ( ! $dom->loadHTML( '<?xml encoding="utf-8" ?>' . $html ) ) {
-		return $html;
+	$previous_use_internal_errors = libxml_use_internal_errors( true );
+
+	try {
+		if ( ! $dom->loadHTML( '<?xml encoding="utf-8" ?>' . $html ) ) {
+			return $html;
+		}
+	} finally {
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous_use_internal_errors );
 	}
-	libxml_clear_errors();
 
 	// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	$root = $dom->getElementsByTagName( 'body' )->item( 0 ) ?? $dom->documentElement;

--- a/lib/github-changelog.php
+++ b/lib/github-changelog.php
@@ -155,6 +155,92 @@ function get_changelog_section_in_description_html( $description ) {
 }
 
 /**
+ * Cleans empty list items and sections from changelog HTML.
+ *
+ * @param string $html The changelog HTML to clean
+ * @return string The cleaned HTML
+ */
+function clean_changelog_html( $html ) {
+	if ( empty( trim( $html ) ) ) {
+		return '';
+	}
+
+	$dom = new DOMDocument();
+	libxml_use_internal_errors( true );
+
+	if ( ! $dom->loadHTML( '<?xml encoding="utf-8" ?>' . $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD ) ) {
+		return $html;
+	}
+	libxml_clear_errors();
+
+	// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	$xpath = new DOMXPath( $dom );
+
+	// Remove empty list items (items with only whitespace or that are completely empty)
+	$empty_list_items = $xpath->query( '//li[not(normalize-space())]' );
+	foreach ( $empty_list_items as $item ) {
+		$item->parentNode->removeChild( $item );
+	}
+
+	// Remove empty ul elements.
+	$empty_lists = $xpath->query( '//ul[not(li)]' );
+	foreach ( $empty_lists as $list ) {
+		$list->parentNode->removeChild( $list );
+	}
+
+	// Find h3 elements followed by no meaningful content.
+	$headings = $xpath->query( '//h3' );
+	foreach ( $headings as $heading ) {
+		$has_content = false;
+		$next_node   = $heading->nextSibling;
+
+		while ( $next_node ) {
+			// Stop at the next heading.
+			if ( XML_ELEMENT_NODE === $next_node->nodeType && 'h3' === $next_node->nodeName ) {
+				break;
+			}
+
+			// Check if this node has meaningful content.
+			if ( XML_ELEMENT_NODE === $next_node->nodeType ) {
+				if ( 'ul' === $next_node->nodeName && $next_node->hasChildNodes() ) {
+					$has_content = true;
+					break;
+				} elseif ( 'p' === $next_node->nodeName && ! empty( trim( $next_node->textContent ) ) ) {
+					$has_content = true;
+					break;
+				}
+			}
+
+			$next_node = $next_node->nextSibling;
+		}
+
+		// Remove heading if it has no content.
+		if ( ! $has_content ) {
+			$heading->parentNode->removeChild( $heading );
+		}
+	}
+
+	$output = $dom->saveHTML();
+	// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+	// Remove XML declaration and doctype if present.
+	$output = preg_replace( '/^<\?xml[^>]*>\s*/', '', $output );
+	$output = preg_replace( '/^<!DOCTYPE[^>]*>\s*/', '', $output );
+
+	// Normalize whitespace - remove blank lines between tags.
+	$output = preg_replace( '/>\s+</', ">\n<", $output );
+	
+	// Ensure consistent formatting with newlines after opening/closing tags.
+	$output = preg_replace( '/<\/h3>\s*</', "</h3>\n<", $output );
+	$output = preg_replace( '/<\/p>\s*</', "</p>\n<", $output );
+	$output = preg_replace( '/<ul>\s*<li>/', "<ul>\n<li>", $output );
+	$output = preg_replace( '/<\/li>\s*<li>/', "</li>\n<li>", $output );
+	$output = preg_replace( '/<\/li>\s*<\/ul>/', "</li>\n</ul>", $output );
+
+	return trim( $output );
+}
+
+/**
  * Finds the changelog section in the PR description and returns the HTML.
  *
  * @param array $pr The PR object from GitHub API
@@ -171,6 +257,13 @@ function get_changelog_html( $pr, $link_to_pr = LINK_TO_PR ) {
 	$description_html = $parsedown->text( $body );
 
 	$changelog_html = get_changelog_section_in_description_html( $description_html );
+
+	if ( empty( $changelog_html ) ) {
+		return null;
+	}
+
+	// Clean empty list items and sections.
+	$changelog_html = clean_changelog_html( $changelog_html );
 
 	if ( empty( $changelog_html ) ) {
 		return null;

--- a/tests/scripts/test-github-changelog.php
+++ b/tests/scripts/test-github-changelog.php
@@ -264,4 +264,194 @@ Foo Bar!';
 			$this->assertEquals( $expected_pr_ids, $pr_ids, "Failed for message: {$message}" );
 		}
 	}
+
+	/**
+	 * @dataProvider clean_changelog_html_provider
+	 */
+	public function test_clean_changelog_html( string $input, string $expected ) {
+		$this->assertEquals(
+			$expected,
+			clean_changelog_html( $input )
+		);
+	}
+
+	public function clean_changelog_html_provider(): array {
+		return array(
+			'empty list items'                      => array(
+				'<h3>Added</h3>
+<ul>
+<li></li>
+<li>   </li>
+<li>Something real</li>
+</ul>',
+				'<h3>Added</h3>
+<ul>
+<li>Something real</li>
+</ul>',
+			),
+			'section with only empty list items'    => array(
+				'<h3>Added</h3>
+<ul>
+<li></li>
+<li>   </li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+<li>Fixed a bug</li>
+</ul>',
+				'<h3>Fixed</h3>
+<ul>
+<li>Fixed a bug</li>
+</ul>',
+			),
+			'multiple empty sections'               => array(
+				'<h3>Added</h3>
+<ul>
+<li></li>
+</ul>
+<h3>Removed</h3>
+<ul>
+<li>   </li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+<li>Fixed a bug</li>
+</ul>',
+				'<h3>Fixed</h3>
+<ul>
+<li>Fixed a bug</li>
+</ul>',
+			),
+			'section with no list at all'           => array(
+				'<h3>Added</h3>
+<h3>Fixed</h3>
+<ul>
+<li>Fixed a bug</li>
+</ul>',
+				'<h3>Fixed</h3>
+<ul>
+<li>Fixed a bug</li>
+</ul>',
+			),
+			'all sections empty'                    => array(
+				'<h3>Added</h3>
+<ul>
+<li></li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+<li></li>
+</ul>',
+				'',
+			),
+			'empty string input'                    => array(
+				'',
+				'',
+			),
+			'whitespace only input'                 => array(
+				'   ',
+				'',
+			),
+			'mixed empty and whitespace list items' => array(
+				'<h3>Changed</h3>
+<ul>
+<li></li>
+<li>
+</li>
+<li>   </li>
+<li>Real change here</li>
+<li>
+	
+</li>
+</ul>',
+				'<h3>Changed</h3>
+<ul>
+<li>Real change here</li>
+</ul>',
+			),
+			'preserves code tags'                   => array(
+				'<h3>Fixed</h3>
+<ul>
+<li></li>
+<li>Fixed bug in <code>my_function()</code></li>
+</ul>',
+				'<h3>Fixed</h3>
+<ul>
+<li>Fixed bug in <code>my_function()</code></li>
+</ul>',
+			),
+		);
+	}
+
+	public function test_get_changelog_html_with_template_format(): void {
+		$pr = array(
+			'body' => '## Changelog Description
+
+<!-- Changelogs are published for our customers -->
+
+### Added
+
+-   <!-- e.g. "Added a new set of filters for MFA status" -->
+-   <!-- e.g. "Dev-env: Added PHP 8.3 image" -->
+
+### Removed
+
+-   <!-- e.g. "Dropped support of Node.js 14" -->
+-
+
+### Fixed
+
+-   <!-- e.g. "Fixed a bug causing blank lines" -->
+-
+
+### Changed
+
+-   <!-- e.g. "Increased priority of wp_mail_from filter" -->
+-   <!-- e.g. "HyperDB: Updated to latest version" -->',
+		);
+
+		$changelog = get_changelog_html( $pr );
+
+		// Should return null because all sections are empty after cleaning
+		$this->assertNull( $changelog );
+	}
+
+	public function test_get_changelog_html_with_partial_template_format(): void {
+		$pr = array(
+			'body' => '## Changelog Description
+
+<!-- Changelogs are published for our customers -->
+
+### Added
+
+-   Added a real feature here
+-   <!-- e.g. "Dev-env: Added PHP 8.3 image" -->
+
+### Removed
+
+-   <!-- e.g. "Dropped support of Node.js 14" -->
+-
+
+### Fixed
+
+-   <!-- e.g. "Fixed a bug causing blank lines" -->
+-
+
+### Changed
+
+-   <!-- e.g. "Increased priority of wp_mail_from filter" -->
+-   <!-- e.g. "HyperDB: Updated to latest version" -->',
+		);
+
+		$changelog = get_changelog_html( $pr );
+
+		// Should only contain the "Added" section with the real content
+		$this->assertEquals(
+			'<h3>Added</h3>
+<ul>
+<li>Added a real feature here</li>
+</ul>',
+			$changelog
+		);
+	}
 }

--- a/tests/scripts/test-github-changelog.php
+++ b/tests/scripts/test-github-changelog.php
@@ -11,6 +11,7 @@ define( 'PR_CHANGELOG_END_MARKER', '<h2>' );
 define( 'WP_CHANGELOG_CATEGORIES', '1,2,3' );
 define( 'WP_CHANGELOG_CHANNEL_IDS', '1,2,3' );
 define( 'WP_CHANGELOG_TERMS', '1,2,3' );
+define( 'WP_CHANGELOG_TAG_IDS', '' );
 define( 'LINK_TO_PR', false );
 define( 'PROJECT_REPONAME', 'test-project' );
 define( 'DEBUG', false );
@@ -453,5 +454,112 @@ Foo Bar!';
 </ul>',
 			$changelog
 		);
+	}
+
+	public function test_generate_changelog_from_prs_with_single_empty_pr(): void {
+		$prs = array(
+			array(
+				'body'   => '## Changelog Description
+
+### Added
+
+-   <!-- e.g. "Added a new feature" -->
+
+### Fixed
+
+-   <!-- e.g. "Fixed a bug" -->',
+				'labels' => array(),
+			),
+		);
+
+		list( $changelog_html ) = generate_changelog_from_prs( $prs );
+
+		// Should return empty string when PR has no real changelog entries
+		$this->assertEmpty( $changelog_html );
+	}
+
+	public function test_generate_changelog_from_prs_with_multiple_empty_prs(): void {
+		$prs = array(
+			array(
+				'body'   => '## Changelog Description
+
+### Added
+
+-   <!-- e.g. "Added a new feature" -->
+
+### Fixed
+
+-   <!-- e.g. "Fixed a bug" -->',
+				'labels' => array(),
+			),
+			array(
+				'body'   => '## Changelog Description
+
+### Removed
+
+-   <!-- e.g. "Dropped support of Node.js 14" -->
+-
+
+### Changed
+
+-   <!-- e.g. "Changed something" -->',
+				'labels' => array(),
+			),
+			array(
+				'body'   => '## Changelog Description
+
+### Fixed
+
+-   
+-',
+				'labels' => array(),
+			),
+		);
+
+		list( $changelog_html ) = generate_changelog_from_prs( $prs );
+
+		// Should return empty string when all PRs have no real changelog entries
+		$this->assertEmpty( $changelog_html );
+	}
+
+	public function test_generate_changelog_from_prs_with_mixed_empty_and_valid(): void {
+		$prs = array(
+			array(
+				'body'   => '## Changelog Description
+
+### Added
+
+-   <!-- e.g. "Added a new feature" -->',
+				'labels' => array(),
+			),
+			array(
+				'body'   => '## Changelog Description
+
+### Fixed
+
+-   Fixed a real bug',
+				'labels' => array(
+					array(
+						'name'        => 'bugfix',
+						'description' => 'ChangelogTagID: 123',
+					),
+				),
+			),
+			array(
+				'body'   => '## Changelog Description
+
+### Added
+
+-   
+-',
+				'labels' => array(),
+			),
+		);
+
+		list( $changelog_html ) = generate_changelog_from_prs( $prs );
+
+		// Should only include the PR with real content
+		$this->assertStringContainsString( 'Fixed a real bug', $changelog_html );
+		$this->assertStringNotContainsString( '<!-- e.g.', $changelog_html );
 	}
 }


### PR DESCRIPTION
This pull request improves the handling and formatting of changelog HTML by introducing a cleaning function to remove empty sections and list items. The main goal is to ensure that empty lists and sections are not included.

**Changelog HTML cleaning and formatting:**

* Added a new `clean_changelog_html` function in `lib/github-changelog.php` to remove empty list items, empty `<ul>` sections, and `<h3>` headings without meaningful content from changelog HTML. The function also normalizes whitespace and formatting.
* Updated the `get_changelog_html` function to use `clean_changelog_html`, and to return `null` if the resulting changelog is empty after cleaning.

**Testing improvements:**

* Added extensive unit tests in `tests/scripts/test-github-changelog.php` to verify the behavior of `clean_changelog_html` with various input scenarios, including empty sections, whitespace, and preservation of code tags. Tests also ensure that changelogs with only template content are removed, and that only sections with real content remain.